### PR TITLE
fixing indentation in the audio_time_features function

### DIFF
--- a/train_audioclassify.py
+++ b/train_audioclassify.py
@@ -526,48 +526,48 @@ def audio_time_features(filename):
         filename=exportfile(newAudio,timesegment[i],timesegment[i+1],filename,i)
         filelist.append(filename)
 
-        featureslist=np.array([0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0,
-                               0,0,0,0])
-        
-        #save 100 ms segments in current folder (delete them after)
-        for j in range(len(filelist)):
-            try:
-                features=featurize(filelist[i])
-                featureslist=featureslist+features 
-                os.remove(filelist[j])
-            except:
-                print('error splicing')
-                featureslist.append('silence')
-                os.remove(filelist[j])
+    featureslist=np.array([0,0,0,0,
+                           0,0,0,0,
+		       	  		   0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0,
+                           0,0,0,0])
+    
+    #save 100 ms segments in current folder (delete them after)
+    for j in range(len(filelist)):
+        try:
+            features=featurize(filelist[i])
+            featureslist=featureslist+features 
+            os.remove(filelist[j])
+        except:
+            print('error splicing')
+            featureslist.append('silence')
+            os.remove(filelist[j])
 
-        #now scale the featureslist array by the length to get mean in each category
-        featureslist=featureslist/segnum
-        
-        return featureslist
+    #now scale the featureslist array by the length to get mean in each category
+    featureslist=featureslist/segnum
+    
+    return featureslist
 
 #FEATURIZE .WAV FILES WITH AUDIO FEATURES --> MAKE JSON (if needed)
 #############################################################


### PR DESCRIPTION
In the audio_time_features function, you accidentally included the rest of the function in the for on line 525. What happens now is it only goes into the first iteration of the for loop and learns from the first segment of this audio file. What you intended to do was have it go through all of the segments and have the featurelist be an average of all of the segments. Therefore the changes I made to this code fix that problem. (You did it correctly in load_audioclassify.py)